### PR TITLE
release 0.3.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,10 +2,11 @@
 
 Format for this file derived from [http://keepachangelog.com](http://keepachangelog.com).
 
-## Unreleased
+## 0.3.0 - 2022-10-07
 
 ### Changed
 
+- _BREAKING_: Removed `lwgeom` support in favor `rttopo`. `librttopo` is now a dependency.
 - _BREAKING_: Renamed `OGR::GeometryExtensions::EWKBIO` to `OGR::Geometry::EWKBIOExtensions`.
 - _BREAKING_: Renamed `OGR::GeometryExtensions::EWKBRecord` to `OGR::Geometry::EWKBRecord`.
 - _BREAKING_: Renamed `OGR::GeometryExtensions::LWGeomWrapper` to `OGR::Geometry::LWGeomExtensions`.

--- a/lib/ffi/gdal/extensions/version.rb
+++ b/lib/ffi/gdal/extensions/version.rb
@@ -3,7 +3,7 @@
 module FFI
   module GDAL
     module Extensions
-      VERSION = '0.2.0'
+      VERSION = '0.3.0'
     end
   end
 end


### PR DESCRIPTION
It looks like we bumped `version.rb` to `0.2.0` in 2019 but never did a proper release.  I'm just going to call this 0.3.0 since a bunch of services were  already using develop.